### PR TITLE
Add `KeyRing::list_keychains` method

### DIFF
--- a/src/multi_keychain/keyring.rs
+++ b/src/multi_keychain/keyring.rs
@@ -79,6 +79,11 @@ where
         self.default_keychain = keychain;
     }
 
+    /// Return all keychain identifiers `K`.
+    pub fn list_keychains(&self) -> &BTreeMap<K, Descriptor<DescriptorPublicKey>> {
+        &self.descriptors
+    }
+
     /// Initial changeset.
     pub fn initial_changeset(&self) -> ChangeSet<K> {
         ChangeSet {


### PR DESCRIPTION
This PR adds a method to retrieve all `K`s from your keyring.

When combined with #3, I would potentially update the method/docs to basically this:

```rust
/// Return all keychain identifiers `K`, with the default keychain first in the vector.
```