### PR TITLE
Add `keychain_balance` method and example on monitoring auxiliary descriptors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,6 @@ required-features = ["rusqlite"]
 [[example]]
 name = "custom_keychain_identifier"
 required-features = ["rusqlite"]
+
+[[example]]
+name = "transient_keychains"

--- a/examples/transient_keychains.rs
+++ b/examples/transient_keychains.rs
@@ -1,0 +1,67 @@
+use bitcoin::{Amount, Network};
+use multi_keychain_wallet::multi_keychain::KeyRing;
+use multi_keychain_wallet::multi_keychain::{fund_keychain, Wallet};
+
+// We can add auxiliary descriptors to our wallet and query their balance separately.
+
+fn main() -> anyhow::Result<()> {
+    let desc1 = "tr(tpubDDr5nR9j92Ud2yS68JmUTX2pGPxs6fVXxoxAnisvdWSy9QsYypCdzGbTtqqQtjTGG9WmFpDfvKKJNbUeKnKCX2YA9KpP558QBzqFvTa7C9S/1/*)";
+    let desc2 = "tr(tpubDDr5nR9j92Ud2yS68JmUTX2pGPxs6fVXxoxAnisvdWSy9QsYypCdzGbTtqqQtjTGG9WmFpDfvKKJNbUeKnKCX2YA9KpP558QBzqFvTa7C9S/2/*)";
+    let desc3 = "tr(tpubDDr5nR9j92Ud2yS68JmUTX2pGPxs6fVXxoxAnisvdWSy9QsYypCdzGbTtqqQtjTGG9WmFpDfvKKJNbUeKnKCX2YA9KpP558QBzqFvTa7C9S/3/*)";
+    let desc4 = "tr(tpubDDr5nR9j92Ud2yS68JmUTX2pGPxs6fVXxoxAnisvdWSy9QsYypCdzGbTtqqQtjTGG9WmFpDfvKKJNbUeKnKCX2YA9KpP558QBzqFvTa7C9S/4/*)";
+
+    let keychain1 = KeychainType::KeychainId(1);
+
+    let keychain2 = KeychainType::KeychainId(2);
+
+    let transient1 = KeychainType::TransientKeychain(1);
+
+    let transient2 = KeychainType::TransientKeychain(2);
+
+    let network = Network::Regtest;
+
+    // Create the wallet with our keyring
+    let mut keyring = KeyRing::new(network);
+
+    for (keychain_identifier, desc) in [
+        (keychain1.clone(), desc1),
+        (keychain2.clone(), desc2),
+        (transient1.clone(), desc3),
+        (transient2.clone(), desc4),
+    ] {
+        keyring.add_descriptor(keychain_identifier, desc);
+    }
+
+    let mut wallet = Wallet::new(keyring);
+
+    // fund the main descriptors
+    fund_keychain(&mut wallet, keychain1.clone());
+
+    // Query the balances
+    let main_balance: Amount = [keychain1, keychain2]
+        .iter()
+        .map(|keychain| wallet.keychain_balance(keychain.clone()).total())
+        .sum();
+
+    let transient_balance: Amount = [transient1, transient2]
+        .iter()
+        .map(|keychain| wallet.keychain_balance(keychain.clone()).total())
+        .sum();
+
+    println!(
+        "Total balance for the main descriptors is: {} sats",
+        main_balance.to_sat()
+    );
+    println!(
+        "Total balance for the transient descriptors is: {} sats",
+        transient_balance.to_sat()
+    );
+
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord)]
+enum KeychainType {
+    KeychainId(u32),
+    TransientKeychain(u32),
+}

--- a/src/multi_keychain.rs
+++ b/src/multi_keychain.rs
@@ -2,10 +2,12 @@
 
 mod changeset;
 pub mod keyring;
+mod test_util;
 mod wallet;
 
 pub use changeset::*;
 pub use keyring::KeyRing;
+pub use test_util::*;
 pub use wallet::*;
 
 /// Alias for [`DescriptorId`](bdk_chain::DescriptorId).

--- a/src/multi_keychain/test_util.rs
+++ b/src/multi_keychain/test_util.rs
@@ -1,0 +1,175 @@
+use crate::bdk_chain::{BlockId, ConfirmationBlockTime, TxUpdate};
+use crate::multi_keychain::{Update, Wallet};
+use alloc::sync::Arc;
+use bitcoin::{
+    absolute, hashes::Hash, transaction, Address, Amount, BlockHash, Network, OutPoint,
+    Transaction, TxIn, TxOut, Txid,
+};
+use core::{fmt, str::FromStr};
+
+pub fn fund_keychain<K>(wallet: &mut Wallet<K>, keychain: K)
+where
+    K: fmt::Debug + Clone + Ord,
+{
+    let receive_address = wallet.reveal_next_address(keychain).unwrap().1;
+    let sendto_address = Address::from_str("bcrt1q395f053hx4rc90n37a8h6ke8q6hv4rdemyewjv")
+        .expect("address")
+        .require_network(Network::Regtest)
+        .unwrap();
+
+    let tx0 = Transaction {
+        output: vec![TxOut {
+            value: Amount::from_sat(76_000),
+            script_pubkey: receive_address.script_pubkey(),
+        }],
+        ..new_tx(0)
+    };
+
+    let tx1 = Transaction {
+        input: vec![TxIn {
+            previous_output: OutPoint {
+                txid: tx0.compute_txid(),
+                vout: 0,
+            },
+            ..Default::default()
+        }],
+        output: vec![
+            TxOut {
+                value: Amount::from_sat(50_000),
+                script_pubkey: receive_address.script_pubkey(),
+            },
+            TxOut {
+                value: Amount::from_sat(25_000),
+                script_pubkey: sendto_address.script_pubkey(),
+            },
+        ],
+        ..new_tx(0)
+    };
+
+    insert_checkpoint(
+        wallet,
+        BlockId {
+            height: 42,
+            hash: BlockHash::all_zeros(),
+        },
+    );
+    insert_checkpoint(
+        wallet,
+        BlockId {
+            height: 1_000,
+            hash: BlockHash::all_zeros(),
+        },
+    );
+    insert_checkpoint(
+        wallet,
+        BlockId {
+            height: 2_000,
+            hash: BlockHash::all_zeros(),
+        },
+    );
+
+    insert_tx(wallet, tx0.clone());
+    insert_anchor(
+        wallet,
+        tx0.compute_txid(),
+        ConfirmationBlockTime {
+            block_id: BlockId {
+                height: 1_000,
+                hash: BlockHash::all_zeros(),
+            },
+            confirmation_time: 100,
+        },
+    );
+
+    insert_tx(wallet, tx1.clone());
+    insert_anchor(
+        wallet,
+        tx1.compute_txid(),
+        ConfirmationBlockTime {
+            block_id: BlockId {
+                height: 2_000,
+                hash: BlockHash::all_zeros(),
+            },
+            confirmation_time: 200,
+        },
+    );
+}
+
+pub fn insert_checkpoint<K>(wallet: &mut Wallet<K>, block: BlockId)
+where
+    K: fmt::Debug + Clone + Ord,
+{
+    let mut cp = wallet.latest_checkpoint();
+    cp = cp.insert(block);
+    wallet.apply_update(Update {
+        chain: Some(cp),
+        ..Default::default()
+    });
+}
+
+/// Inserts a transaction into the local view, assuming it is currently present in the mempool.
+///
+/// This can be used, for example, to track a transaction immediately after it is broadcast.
+pub fn insert_tx<K>(wallet: &mut Wallet<K>, tx: Transaction)
+where
+    K: fmt::Debug + Clone + Ord,
+{
+    let txid = tx.compute_txid();
+    let seen_at = std::time::UNIX_EPOCH.elapsed().unwrap().as_secs();
+    let mut tx_update = TxUpdate::default();
+    tx_update.txs = vec![Arc::new(tx)];
+    tx_update.seen_ats = [(txid, seen_at)].into();
+    wallet.apply_update(Update {
+        tx_update,
+        ..Default::default()
+    });
+}
+
+/// Simulates confirming a tx with `txid` by applying an update to the wallet containing
+/// the given `anchor`. Note: to be considered confirmed the anchor block must exist in
+/// the current active chain.
+pub fn insert_anchor<K>(wallet: &mut Wallet<K>, txid: Txid, anchor: ConfirmationBlockTime)
+where
+    K: fmt::Debug + Clone + Ord,
+{
+    let mut tx_update = TxUpdate::default();
+    tx_update.anchors = [(anchor, txid)].into();
+    wallet.apply_update(Update {
+        tx_update,
+        ..Default::default()
+    });
+}
+
+/// A new empty transaction with the given locktime
+pub fn new_tx(locktime: u32) -> Transaction {
+    Transaction {
+        version: transaction::Version::ONE,
+        lock_time: absolute::LockTime::from_consensus(locktime),
+        input: vec![],
+        output: vec![],
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::multi_keychain::KeyRing;
+
+    use super::*;
+
+    #[test]
+    fn keychain_is_funded() {
+        use crate::bdk_chain::DescriptorExt;
+        use bitcoin::secp256k1::Secp256k1;
+        use miniscript::Descriptor;
+        let desc_str = "tr(tpubDDr5nR9j92Ud2yS68JmUTX2pGPxs6fVXxoxAnisvdWSy9QsYypCdzGbTtqqQtjTGG9WmFpDfvKKJNbUeKnKCX2YA9KpP558QBzqFvTa7C9S/1/*)";
+        let desc = Descriptor::parse_descriptor(&Secp256k1::new(), desc_str)
+            .expect("failed to parse descriptor")
+            .0;
+        let did = desc.descriptor_id();
+        let mut keyring = KeyRing::new(Network::Regtest);
+        keyring.add_descriptor(did, desc);
+        let mut wallet = Wallet::new(keyring);
+        fund_keychain(&mut wallet, did);
+        assert_eq!(wallet.total_balance().confirmed, Amount::from_sat(50_000));
+    }
+}

--- a/src/multi_keychain/wallet.rs
+++ b/src/multi_keychain/wallet.rs
@@ -227,6 +227,11 @@ where
             Some(&self.stage)
         }
     }
+
+    /// Returns the latest checkpoint.
+    pub fn latest_checkpoint(&self) -> CheckPoint {
+        self.chain.tip()
+    }
 }
 
 #[cfg(feature = "rusqlite")]
@@ -283,6 +288,16 @@ pub struct Update<K> {
     pub tx_update: bdk_chain::TxUpdate<ConfirmationBlockTime>,
     /// last active keychain indices
     pub last_active_indices: BTreeMap<K, u32>,
+}
+
+impl<K> Default for Update<K> {
+    fn default() -> Self {
+        Self {
+            chain: None,
+            tx_update: bdk_chain::TxUpdate::<ConfirmationBlockTime>::default(),
+            last_active_indices: BTreeMap::new(),
+        }
+    }
 }
 
 impl<K> From<bdk_chain::spk_client::FullScanResponse<K>> for Update<K> {

--- a/src/multi_keychain/wallet.rs
+++ b/src/multi_keychain/wallet.rs
@@ -141,10 +141,23 @@ where
     }
 
     /// Compute the balance.
-    pub fn balance(&self) -> bdk_chain::Balance {
+    pub fn total_balance(&self) -> bdk_chain::Balance {
         use bdk_chain::CanonicalizationParams;
         let chain = &self.chain;
         let outpoints = self.tx_graph.index.outpoints().clone();
+        self.tx_graph.graph().balance(
+            chain,
+            chain.tip().block_id(),
+            CanonicalizationParams::default(),
+            outpoints,
+            |_, _| false,
+        )
+    }
+
+    pub fn keychain_balance(&self, keychain: K) -> bdk_chain::Balance {
+        use bdk_chain::CanonicalizationParams;
+        let chain = &self.chain;
+        let outpoints = self.tx_graph.index.keychain_outpoints(keychain);
         self.tx_graph.graph().balance(
             chain,
             chain.tip().block_id(),


### PR DESCRIPTION
Inspired by 2nd point in [bdk#5](https://github.com/bitcoindevkit/bdk/issues/57). 
The example can be further extended to do the "sweep" mentioned in the linked issue when bdk-tx is ready!
Notes
- `keychain_balance` method to query balance per keychain
- renamed `balance` method to `total_balance`
- added `latest_checkpoint` method to Wallet<K> just like we have in bdk_wallet
- added impl of Default trait for Update
- some testing utilities (funding a keychain of the test wallet ) borrowing heavily from test_utils in bdk_wallet

Related to #2 