### PR TITLE
feat: persist default keychain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ path = "."
 
 [dev-dependencies]
 anyhow = "1"
+tempfile = "3.21.0"
 
 [[example]]
 name = "keyring"

--- a/examples/keyring.rs
+++ b/examples/keyring.rs
@@ -34,7 +34,7 @@ fn main() -> anyhow::Result<()> {
             let mut keyring = KeyRing::new(network, desc1_id, desc1);
 
             // Add a secondary keychain to the keyring
-            keyring.add_descriptor(desc2_id.clone(), desc2, false);
+            keyring.add_descriptor(desc2_id, desc2, false);
 
             let mut wallet = Wallet::new(keyring);
             wallet.persist_to_sqlite(&mut conn)?;

--- a/src/multi_keychain/wallet.rs
+++ b/src/multi_keychain/wallet.rs
@@ -137,6 +137,11 @@ where
         self.tx_graph.index.keychains()
     }
 
+    /// Get the default keychain
+    pub fn default_keychain(&self) -> K {
+        self.keyring.default_keychain()
+    }
+
     /// Compute the balance.
     pub fn balance(&self) -> bdk_chain::Balance {
         use bdk_chain::CanonicalizationParams;


### PR DESCRIPTION
Builds on #5 

This pr:
- adds persistence for default keychain by introducing another column (`is_default`) in the sqlite table for descriptors.
- adds a method to get `Wallet`'s default keychain
- adds a test to check default keychain is being persisted correctly

Some questions:
- should `prepare` be used instead of `prepare_cached` in the places where we update the `is_default` column of a descriptor already persisted ?