### PR TITLE
feat!: Add functionality for sync and full scan

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.1"
 edition = "2021"
 rust-version = "1.63.0"
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 bdk_wallet = { version = "2.0.0", default-features = false }
 bitcoin = { version = "0.32.6", features = ["serde", "base64"], default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ path = "."
 [dev-dependencies]
 anyhow = "1"
 tempfile = "3.21.0"
+bdk_electrum = {version = "0.23.1"}
 
 [[example]]
 name = "keyring"
@@ -37,3 +38,6 @@ required-features = ["rusqlite"]
 [[example]]
 name = "default_keychain"
 required-features = ["rusqlite"]
+
+[[example]]
+name = "electrum_example"

--- a/examples/custom_keychain_identifier.rs
+++ b/examples/custom_keychain_identifier.rs
@@ -91,50 +91,50 @@ fn main() -> anyhow::Result<()> {
         "=".repeat(50)
     );
 
-    let (keychain_and_index, addr) = wallet.reveal_next_default_address_unwrap();
+    let addrinfo = wallet.reveal_next_default_address_unwrap();
     println!(
-        "Default keychain address (index {:?}): {}",
-        keychain_and_index.1, addr
+        "Default keychain address (index {}): {}",
+        addrinfo.index, addrinfo.address
     );
 
-    let (keychain_and_index, addr) = wallet.reveal_next_address(keychain_johnny.clone()).unwrap();
+    let addrinfo_johnny = wallet.reveal_next_address(keychain_johnny.clone()).unwrap();
     println!(
-        "Johnny's address (index {:?}):         {}",
-        keychain_and_index.1, addr
+        "Johnny's address (index {}):         {}",
+        addrinfo_johnny.index, addrinfo_johnny.address
     );
 
-    let (keychain_and_index, addr) = wallet
+    let addrinfo_samantha = wallet
         .reveal_next_address(keychain_samantha.clone())
         .unwrap();
     println!(
-        "Samantha's address (index {:?}):       {}",
-        keychain_and_index.1, addr
+        "Samantha's address (index {}):       {}",
+        addrinfo_samantha.index, addrinfo_samantha.address
     );
 
-    let (keychain_and_index, addr) = wallet.reveal_next_address(keychain_riley.clone()).unwrap();
+    let addrinfo_riley = wallet.reveal_next_address(keychain_riley.clone()).unwrap();
     println!(
         "Riley's address (index {:?}):          {}",
-        keychain_and_index.1, addr
+        addrinfo_riley.index, addrinfo_riley.address
     );
 
-    let (keychain_and_index, addr) = wallet.reveal_next_address(keychain_max.clone()).unwrap();
+    let addrinfo_max = wallet.reveal_next_address(keychain_max.clone()).unwrap();
     println!(
         "Max's address (index {:?}):            {}",
-        keychain_and_index.1, addr
+        addrinfo_max.index, addrinfo_max.address
     );
 
-    let (keychain_and_index, addr) = wallet
+    let addrinfo_penelope = wallet
         .reveal_next_address(keychain_penelope.clone())
         .unwrap();
     println!(
         "Penelope's address (index {:?}):       {}",
-        keychain_and_index.1, addr
+        addrinfo_penelope.index, addrinfo_penelope.address
     );
 
-    let (keychain_and_index, addr) = wallet.reveal_next_address(keychain_george.clone()).unwrap();
+    let addrinfo_george = wallet.reveal_next_address(keychain_george.clone()).unwrap();
     println!(
         "George's address (index {:?}):         {}",
-        keychain_and_index.1, addr
+        addrinfo_george.index, addrinfo_george.address
     );
 
     Ok(())

--- a/examples/default_keychain.rs
+++ b/examples/default_keychain.rs
@@ -48,8 +48,11 @@ fn main() -> anyhow::Result<()> {
         }
     };
 
-    let (indexed, addr) = wallet.reveal_next_default_address_unwrap();
-    println!("Address: {:?} {}", indexed, addr);
+    let addrinfo = wallet.reveal_next_default_address_unwrap();
+    println!(
+        "Address:   ({}, {}) {}",
+        addrinfo.keychain, addrinfo.index, addrinfo.address
+    );
 
     let changeset = wallet.persist_to_sqlite(&mut conn)?;
     println!("Change persisted: {}", changeset.is_some());

--- a/examples/electrum_example.rs
+++ b/examples/electrum_example.rs
@@ -1,0 +1,48 @@
+use bdk_wallet::KeychainKind;
+use bitcoin::Network;
+use multi_keychain_wallet::multi_keychain::{KeyRing, Wallet};
+
+use bdk_electrum::{electrum_client::Client, BdkElectrumClient};
+
+const STOP_GAP: usize = 50;
+const BATCH_SIZE: usize = 5;
+const EXTERNAL_DESCRIPTOR: &str = "tr(tprv8ZgxMBicQKsPdrjwWCyXqqJ4YqcyG4DmKtjjsRt29v1PtD3r3PuFJAjWytzcvSTKnZAGAkPSmnrdnuHWxCAwy3i1iPhrtKAfXRH7dVCNGp6/86'/1'/0'/0/*)#g9xn7wf9";
+const INTERNAL_DESCRIPTOR: &str = "tr(tprv8ZgxMBicQKsPdrjwWCyXqqJ4YqcyG4DmKtjjsRt29v1PtD3r3PuFJAjWytzcvSTKnZAGAkPSmnrdnuHWxCAwy3i1iPhrtKAfXRH7dVCNGp6/86'/1'/0'/1/*)#e3rjrmea";
+
+fn main() {
+    // Construct wallet
+    let mut keyring =
+        KeyRing::<KeychainKind>::new(Network::Signet, KeychainKind::External, EXTERNAL_DESCRIPTOR);
+    keyring.add_descriptor(KeychainKind::Internal, INTERNAL_DESCRIPTOR, false);
+
+    let mut wallet = Wallet::new(keyring);
+
+    let balance = wallet.balance();
+    println!("Balance before syncing: {} sats", balance.total().to_sat());
+
+    // Reveal address
+    let address = wallet.reveal_next_default_address_unwrap();
+    println!("Address revealed: {}", address.address);
+
+    let client = BdkElectrumClient::new(Client::new("ssl://mempool.space:60602").unwrap());
+
+    // Perform sync
+    let sync_request = wallet.start_sync_with_revealed_spks();
+    let update = client.sync(sync_request, BATCH_SIZE, true).unwrap();
+
+    wallet.apply_update(update);
+
+    let balance = wallet.balance();
+    println!("Balance after sync: {} sats", balance.total().to_sat());
+
+    // Perform full scan
+    let full_scan_request = wallet.start_full_scan();
+    let update = client
+        .full_scan(full_scan_request, STOP_GAP, BATCH_SIZE, true)
+        .unwrap();
+
+    wallet.apply_update(update);
+
+    let balance = wallet.balance();
+    println!("Balance after full scan: {} sats", balance.total().to_sat());
+}

--- a/examples/keyring.rs
+++ b/examples/keyring.rs
@@ -43,12 +43,18 @@ fn main() -> anyhow::Result<()> {
     };
 
     // Reveal an address on the default keychain
-    let (indexed, addr) = wallet.reveal_next_default_address_unwrap();
-    println!("Address on default keychain:   {:?} {}", indexed, addr);
+    let addrinfo = wallet.reveal_next_default_address_unwrap();
+    println!(
+        "Address on default keychain:   ({}, {}) {}",
+        addrinfo.keychain, addrinfo.index, addrinfo.address
+    );
 
     // Reveal an address on another keychain
-    let (indexed2, addr2) = wallet.reveal_next_address(desc2_id).unwrap();
-    println!("Address on secondary keychain: {:?} {}", indexed2, addr2);
+    let addrinfo2 = wallet.reveal_next_address(desc2_id).unwrap();
+    println!(
+        "Address on default keychain:   ({}, {}) {}",
+        addrinfo2.keychain, addrinfo.index, addrinfo2.address
+    );
 
     let changeset = wallet.persist_to_sqlite(&mut conn)?;
     println!("Change persisted: {}", changeset.is_some());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![warn(missing_docs)]
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 extern crate alloc;
 


### PR DESCRIPTION
Notes
- Also replaced `KeychainIndexed` with `AddressInfo` type as the latter is used in `bdk_wallet` and felt more readable. Will revert the change if `KeychainIndexed` is preferred.
- Added a `book_of_bdk` based electrum example to test the functions added.
- Documentation for the new functions is sparse right now since this crate is a POC, can add more following `bdk_wallet` if its desirable.
- The electrum example also shows how to create the `KeychainKind` based wallets ( #10  ).