### PR TITLE
feat: add methods to `Wallet` for block-by-block syncing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ path = "."
 anyhow = "1"
 tempfile = "3.21.0"
 bdk_electrum = {version = "0.23.1"}
+bdk_bitcoind_rpc = {version = "0.22.0"}
 
 [[example]]
 name = "keyring"
@@ -41,3 +42,6 @@ required-features = ["rusqlite"]
 
 [[example]]
 name = "electrum_example"
+
+[[example]]
+name = "rpc_example"

--- a/examples/rpc_example.rs
+++ b/examples/rpc_example.rs
@@ -1,0 +1,87 @@
+use miniscript::Descriptor;
+use multi_keychain_wallet::bdk_chain::{DescriptorExt, DescriptorId};
+use std::sync::Arc;
+
+use bitcoin::{secp256k1::Secp256k1, Network, Transaction};
+use multi_keychain_wallet::multi_keychain::{KeyRing, Wallet};
+
+use bdk_bitcoind_rpc::{
+    bitcoincore_rpc::{Auth, Client},
+    Emitter,
+};
+
+const USER: &str = "alice";
+const PASSWORD: &str = "password";
+const EXTERNAL_DESCRIPTOR: &str = "tr(tprv8ZgxMBicQKsPdrjwWCyXqqJ4YqcyG4DmKtjjsRt29v1PtD3r3PuFJAjWytzcvSTKnZAGAkPSmnrdnuHWxCAwy3i1iPhrtKAfXRH7dVCNGp6/86'/1'/0'/0/*)#g9xn7wf9";
+const INTERNAL_DESCRIPTOR: &str = "tr(tprv8ZgxMBicQKsPdrjwWCyXqqJ4YqcyG4DmKtjjsRt29v1PtD3r3PuFJAjWytzcvSTKnZAGAkPSmnrdnuHWxCAwy3i1iPhrtKAfXRH7dVCNGp6/86'/1'/0'/1/*)#e3rjrmea";
+
+fn main() {
+    let mut keyring = KeyRing::<DescriptorId>::new(
+        Network::Regtest,
+        get_descriptor_id(EXTERNAL_DESCRIPTOR),
+        EXTERNAL_DESCRIPTOR,
+    );
+    keyring.add_descriptor(
+        get_descriptor_id(INTERNAL_DESCRIPTOR),
+        INTERNAL_DESCRIPTOR,
+        false,
+    );
+    let mut wallet = Wallet::new(keyring);
+
+    let balance = wallet.balance();
+    println!("Balance before syncing: {}", balance);
+
+    let address = wallet.reveal_next_default_address_unwrap();
+    println!("Address revealed: {}", address.address);
+
+    let rpc_client: Client = Client::new(
+        "http://127.0.0.1:18443",
+        Auth::UserPass(USER.to_string(), PASSWORD.to_string()),
+    )
+    .unwrap();
+
+    let wallet_tip = wallet.latest_checkpoint();
+    println!(
+        "Current wallet tip is at hash: {} and height:{}",
+        wallet_tip.hash(),
+        wallet_tip.height()
+    );
+
+    let mut emitter = Emitter::new(
+        &rpc_client,
+        wallet_tip.clone(),
+        wallet_tip.height(),
+        std::iter::empty::<Arc<Transaction>>(),
+    );
+
+    println!("Syncing blocks...");
+
+    while let Some(block) = emitter.next_block().unwrap() {
+        wallet
+            .apply_block_connected_to(&block.block, block.block_height(), block.connected_to())
+            .unwrap();
+    }
+
+    let new_wallet_tip = wallet.latest_checkpoint();
+    println!(
+        "Current wallet tip is at hash: {} and height:{}",
+        new_wallet_tip.hash(),
+        new_wallet_tip.height()
+    );
+
+    println!("Syncing mempool...");
+    let mempool_emissions = emitter.mempool().unwrap();
+    wallet.apply_unconfirmed_txs(mempool_emissions.update);
+    wallet.apply_evicted_txs(mempool_emissions.evicted);
+
+    let balance = wallet.balance();
+    println!("Balance after syncing: {}", balance);
+}
+
+/// Helper to pull the descriptor ID out of a descriptor string
+fn get_descriptor_id(s: &str) -> DescriptorId {
+    let desc = Descriptor::parse_descriptor(&Secp256k1::new(), s)
+        .expect("failed to parse descriptor")
+        .0;
+    desc.descriptor_id()
+}

--- a/examples/rpc_example.rs
+++ b/examples/rpc_example.rs
@@ -1,21 +1,21 @@
+use bitcoin::{secp256k1::Secp256k1, Network, Transaction};
 use miniscript::Descriptor;
 use multi_keychain_wallet::bdk_chain::{DescriptorExt, DescriptorId};
-use std::sync::Arc;
-
-use bitcoin::{secp256k1::Secp256k1, Network, Transaction};
 use multi_keychain_wallet::multi_keychain::{KeyRing, Wallet};
+use std::path::PathBuf;
+use std::{env, sync::Arc};
 
 use bdk_bitcoind_rpc::{
     bitcoincore_rpc::{Auth, Client},
     Emitter,
 };
 
-const USER: &str = "alice";
-const PASSWORD: &str = "password";
 const EXTERNAL_DESCRIPTOR: &str = "tr(tprv8ZgxMBicQKsPdrjwWCyXqqJ4YqcyG4DmKtjjsRt29v1PtD3r3PuFJAjWytzcvSTKnZAGAkPSmnrdnuHWxCAwy3i1iPhrtKAfXRH7dVCNGp6/86'/1'/0'/0/*)#g9xn7wf9";
 const INTERNAL_DESCRIPTOR: &str = "tr(tprv8ZgxMBicQKsPdrjwWCyXqqJ4YqcyG4DmKtjjsRt29v1PtD3r3PuFJAjWytzcvSTKnZAGAkPSmnrdnuHWxCAwy3i1iPhrtKAfXRH7dVCNGp6/86'/1'/0'/1/*)#e3rjrmea";
 
 fn main() {
+    let cookie_file = env::var("RPC_COOKIE").unwrap_or("../.bitcoin/regtest/.cookie".to_string());
+
     let mut keyring = KeyRing::<DescriptorId>::new(
         Network::Regtest,
         get_descriptor_id(EXTERNAL_DESCRIPTOR),
@@ -36,7 +36,7 @@ fn main() {
 
     let rpc_client: Client = Client::new(
         "http://127.0.0.1:18443",
-        Auth::UserPass(USER.to_string(), PASSWORD.to_string()),
+        Auth::CookieFile(PathBuf::from(cookie_file)),
     )
     .unwrap();
 

--- a/src/multi_keychain/wallet.rs
+++ b/src/multi_keychain/wallet.rs
@@ -3,7 +3,7 @@ use alloc::{
     sync::Arc,
 };
 use core::{
-    fmt::{self, Debug},
+    fmt::{self, Debug, Display},
     ops::Deref,
 };
 
@@ -16,7 +16,7 @@ use bdk_chain::{
     keychain_txout::{
         FullScanRequestBuilderExt, KeychainTxOutIndex, SyncRequestBuilderExt, DEFAULT_LOOKAHEAD,
     },
-    local_chain::{ApplyHeaderError, CannotConnectError, LocalChain},
+    local_chain::{ApplyHeaderError, LocalChain},
     spk_client::{
         FullScanRequest, FullScanRequestBuilder, FullScanResponse, SyncRequest, SyncRequestBuilder,
         SyncResponse,
@@ -392,6 +392,22 @@ where
     }
 }
 
+/// Error returned by [`apply_block`] and [`apply_block_connected_to`]
+/// when underlying call to [`apply_header_connected_to`] errs.
+///
+///
+/// [`apply_header_connected_to`]: bdk_chain::local_chain::LocalChain::apply_header_connected_to
+/// [`apply_block`]: Wallet::apply_block
+/// [`apply_block_connected_to`]: Wallet::apply_block_connected_to
+#[derive(Debug)]
+pub struct ApplyBlockError(ApplyHeaderError);
+
+impl Display for ApplyBlockError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "the block cannot be applied: {}", self.0)
+    }
+}
+
 /// Methods for block-by-block syncing
 impl<K> Wallet<K>
 where
@@ -401,7 +417,7 @@ where
     /// and `prev_blockhash`.
     ///
     /// [`apply_block_connected_to`]: Self::apply_block_connected_to
-    pub fn apply_block(&mut self, block: &Block, height: u32) -> Result<(), CannotConnectError> {
+    pub fn apply_block(&mut self, block: &Block, height: u32) -> Result<(), ApplyBlockError> {
         let connected_to = match height.checked_sub(1) {
             Some(prev_ht) => BlockId {
                 height: prev_ht,
@@ -413,12 +429,6 @@ where
             },
         };
         self.apply_block_connected_to(block, height, connected_to)
-            .map_err(|err| match err {
-                ApplyHeaderError::InconsistentBlocks => {
-                    unreachable!("connected_to is derived from the block so must be consistent")
-                }
-                ApplyHeaderError::CannotConnect(err) => err,
-            })
     }
 
     /// Connects the `block` of `height` to the internal chain and applies relevant transactions from the block to the wallet.
@@ -430,11 +440,12 @@ where
         block: &Block,
         height: u32,
         connected_to: BlockId,
-    ) -> Result<(), ApplyHeaderError> {
+    ) -> Result<(), ApplyBlockError> {
         let mut changeset = ChangeSet::default();
         changeset.merge(
             self.chain
-                .apply_header_connected_to(&block.header, height, connected_to)?
+                .apply_header_connected_to(&block.header, height, connected_to)
+                .map_err(ApplyBlockError)?
                 .into(),
         );
         changeset.merge(self.tx_graph.apply_block_relevant(block, height).into());

--- a/src/multi_keychain/wallet.rs
+++ b/src/multi_keychain/wallet.rs
@@ -1,6 +1,13 @@
-use core::{fmt, ops::Deref};
+use alloc::{
+    collections::{btree_map::BTreeMap, btree_set::BTreeSet},
+    sync::Arc,
+};
+use core::{
+    fmt::{self, Debug},
+    ops::Deref,
+};
 
-use bitcoin::Address;
+use bitcoin::{Address, Block, Transaction, Txid};
 use miniscript::{Descriptor, DescriptorPublicKey};
 
 #[cfg(feature = "rusqlite")]
@@ -9,16 +16,15 @@ use bdk_chain::{
     keychain_txout::{
         FullScanRequestBuilderExt, KeychainTxOutIndex, SyncRequestBuilderExt, DEFAULT_LOOKAHEAD,
     },
-    local_chain::LocalChain,
+    local_chain::{ApplyHeaderError, CannotConnectError, LocalChain},
     spk_client::{
         FullScanRequest, FullScanRequestBuilder, FullScanResponse, SyncRequest, SyncRequestBuilder,
         SyncResponse,
     },
-    CheckPoint, ConfirmationBlockTime, IndexedTxGraph, Merge,
+    BlockId, CanonicalizationParams, CheckPoint, ConfirmationBlockTime, IndexedTxGraph, Merge,
 };
 
 use crate::bdk_chain;
-use crate::collections::BTreeMap;
 use crate::multi_keychain::{ChangeSet, KeyRing};
 
 /// Alias for a [`IndexedTxGraph`].
@@ -179,6 +185,11 @@ where
     /// Obtain a reference to the local chain.
     pub fn local_chain(&self) -> &LocalChain {
         &self.chain
+    }
+
+    /// Returns the latest `CheckPoint`.
+    pub fn latest_checkpoint(&self) -> CheckPoint {
+        self.chain.tip()
     }
 
     /// Apply update.
@@ -378,6 +389,97 @@ where
         FullScanRequest::builder()
             .chain_tip(self.chain.tip())
             .spks_from_indexer(&self.tx_graph.index)
+    }
+}
+
+/// Methods for block-by-block syncing
+impl<K> Wallet<K>
+where
+    K: Ord + Clone + fmt::Debug,
+{
+    /// This is equivalent to calling [`apply_block_connected_to`] with `connected_to` parameter corresponding to `height-1`
+    /// and `prev_blockhash`.
+    ///
+    /// [`apply_block_connected_to`]: Self::apply_block_connected_to
+    pub fn apply_block(&mut self, block: &Block, height: u32) -> Result<(), CannotConnectError> {
+        let connected_to = match height.checked_sub(1) {
+            Some(prev_ht) => BlockId {
+                height: prev_ht,
+                hash: block.header.prev_blockhash,
+            },
+            None => BlockId {
+                height,
+                hash: block.block_hash(),
+            },
+        };
+        self.apply_block_connected_to(block, height, connected_to)
+            .map_err(|err| match err {
+                ApplyHeaderError::InconsistentBlocks => {
+                    unreachable!("connected_to is derived from the block so must be consistent")
+                }
+                ApplyHeaderError::CannotConnect(err) => err,
+            })
+    }
+
+    /// Connects the `block` of `height` to the internal chain and applies relevant transactions from the block to the wallet.
+    ///
+    /// **WARNING**: The wallet must be persisted after a call to this method if you need the inserted block data to be reloaded
+    /// after closing the wallet.
+    pub fn apply_block_connected_to(
+        &mut self,
+        block: &Block,
+        height: u32,
+        connected_to: BlockId,
+    ) -> Result<(), ApplyHeaderError> {
+        let mut changeset = ChangeSet::default();
+        changeset.merge(
+            self.chain
+                .apply_header_connected_to(&block.header, height, connected_to)?
+                .into(),
+        );
+        changeset.merge(self.tx_graph.apply_block_relevant(block, height).into());
+        self.stage.merge(changeset);
+        Ok(())
+    }
+
+    /// Filters the relevant transactions from `unconfirmed_txs` and applies to wallet.
+    ///
+    /// This method takes in an iterator of `(tx, last_seen)` where `last_seen` is the timestamp of
+    /// when the transaction was last seen, in the mempool. This is used for conflict resolution
+    /// when there is conflicting unconfirmed transactions. The transaction with the later
+    /// `last_seen` is prioritized.
+    /// **WARNING**: The wallet must be persisted after a call to this method if you need the applied unconfirmed txs to be reloaded
+    /// after closing the wallet.
+    pub fn apply_unconfirmed_txs<T: Into<Arc<Transaction>>>(
+        &mut self,
+        unconfirmed_txs: impl IntoIterator<Item = (T, u64)>,
+    ) {
+        let tx_graph_changeset = self
+            .tx_graph
+            .batch_insert_relevant_unconfirmed(unconfirmed_txs);
+        self.stage.merge(tx_graph_changeset.into());
+    }
+
+    /// Apply evictions of the given transaction IDs with their associated timestamps.
+    pub fn apply_evicted_txs(&mut self, evicted_txs: impl IntoIterator<Item = (Txid, u64)>) {
+        let chain = &self.chain;
+        let canon_txids: BTreeSet<Txid> = self
+            .tx_graph
+            .graph()
+            .list_canonical_txs(
+                chain,
+                chain.tip().block_id(),
+                CanonicalizationParams::default(),
+            )
+            .map(|c_tx| c_tx.tx_node.txid)
+            .collect();
+
+        let tx_graph_changeset = self.tx_graph.batch_insert_relevant_evicted_at(
+            evicted_txs
+                .into_iter()
+                .filter(|(txid, _)| canon_txids.contains(txid)),
+        );
+        self.stage.merge(tx_graph_changeset.into());
     }
 }
 


### PR DESCRIPTION
Also added an rpc_example for testing the functions added.

The setup to test is:

bitcoin.conf
```
regtest=1

[regtest]
server=1
```

commands:
```
rm -rf .bitcoin/regtest/
bitcoind -fallbackfee=0.0001
bitcoin-cli createwallet ""
addr=$(bitcoin-cli getnewaddress)
bitcoin-cli generatetoaddress 101 $addr
bitcoin-cli sendtoaddress "bcrt1pkar3gerekw8f9gef9vn9xz0qypytgacp9wa5saelpksdgct33qdqan7c89" 1
bitcoin-cli generatetoaddress 1 $addr
bitcoin-cli sendtoaddress "bcrt1pkar3gerekw8f9gef9vn9xz0qypytgacp9wa5saelpksdgct33qdqan7c89" 1
```
Only one change from the `bdk_wallet` implementation is in the use of  `BTreeSet` instead of `Vec` to collect canonical transactions in `apply_evicted_txs`. I felt that since sets give us better lookup time complexity it would be better to use.